### PR TITLE
Use tailwindcss/plugin for plugin declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
 const flatten = require('flat')
+const plugin = require('tailwindcss/plugin')
 
 
 const FLATTEN_CONFIG = { delimiter: '-', maxDepth: 2 }
@@ -16,7 +17,7 @@ const prefixNegativeModifiers = function(base, modifier) {
 }
 
 
-module.exports = function (spinnerConfig = {}) {
+function pluginFactory(spinnerConfig = {}) {
   return function ({
     addUtilities, addComponents, addBase, addVariant,
     e, prefix, theme, variants, config,
@@ -118,3 +119,5 @@ module.exports = function (spinnerConfig = {}) {
     })
   }
 }
+
+module.exports = plugin.withOptions(pluginFactory)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const prefixNegativeModifiers = function(base, modifier) {
 }
 
 
-module.exports = function () {
+module.exports = function (spinnerConfig = {}) {
   return function ({
     addUtilities, addComponents, addBase, addVariant,
     e, prefix, theme, variants, config,
@@ -90,8 +90,11 @@ module.exports = function () {
       speed: '500ms',
     }
 
+    const baseClassName = spinnerConfig.className || 'spinner'
+    const themeKey = spinnerConfig.themeKey || 'spinner'
+
     const pluginUtilities = {
-      spinner: buildDefaultValuesObject(defaultConfig, 'spinner'),
+      [baseClassName]: buildDefaultValuesObject(defaultConfig, themeKey),
     }
 
     Object.entries(pluginUtilities)

--- a/readme.md
+++ b/readme.md
@@ -43,10 +43,13 @@ yarn add -D tailwindcss-spinner
   },
 
   plugins: [
-    require('tailwindcss-spinner')(), // no options to configure
+    // optional configuration for resulting class name and/or tailwind theme key
+    require('tailwindcss-spinner')({ className: 'spinner', themeKey: 'spinner' }),
   ],
 }
 ```
+
+### Resulting CSS:
 
 ```css
 .spinner {

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ const generatePluginCss = (testConfig = {}, pluginOptions) => {
     .then(result => result.css)
 }
 
-test.skip('can not pass direct require() into tailwind plugin', () => {
+test('can pass direct require() into tailwind plugin', () => {
   const sandboxConfig = {
     theme: {
       screens: { 'sm': '640px' },

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ expect.extend({ toMatchCss: require('jest-matcher-css') })
 
 
 // const defaultConfig = require('tailwindcss/defaultConfig')
-const generatePluginCss = (testConfig = {}, pluginOptions = {}) => {
+const generatePluginCss = (testConfig = {}, pluginOptions) => {
   const sandboxConfig = {
     theme: {
       screens: { 'sm': '640px' },
@@ -17,7 +17,7 @@ const generatePluginCss = (testConfig = {}, pluginOptions = {}) => {
     corePlugins: false,
     plugins: [ plugin(pluginOptions) ],
   }
-  const postcssPlugins =[
+  const postcssPlugins = [
     tailwindcss(_.merge(sandboxConfig, testConfig)),
   ]
 
@@ -26,6 +26,23 @@ const generatePluginCss = (testConfig = {}, pluginOptions = {}) => {
     .then(result => result.css)
 }
 
+test.skip('can not pass direct require() into tailwind plugin', () => {
+  const sandboxConfig = {
+    theme: {
+      screens: { 'sm': '640px' },
+    },
+    corePlugins: false,
+    plugins: [ require('./index.js') ],
+  }
+  const postcssPlugins = [
+    tailwindcss(sandboxConfig),
+  ]
+
+  return postcss(postcssPlugins)
+    .process('@tailwind utilities', { from: undefined })
+    .then(result => result.css)
+    .then(css => expect(css).toEqual(expect.stringContaining('.spinner')))
+})
 
 test('generates default utilities and responsive variants', () => {
   const testConfig = {}

--- a/test.js
+++ b/test.js
@@ -197,3 +197,121 @@ test('utilities can be customized', () => {
 
   return generatePluginCss(testConfig).then(css => expect(css).toMatchCss(expectedCss))
 })
+
+test('class name and theme key can be customized', () => {
+  const testConfig = {
+    theme: {
+      customSpinner: {
+        default: {
+          color: '#dae1e7',
+          size: '1em',
+          border: '2px',
+          speed: '500ms',
+        },
+        md: {
+          color: 'currentColor',
+          size: '2em',
+          border: '2px',
+          speed: '500ms',
+        },
+      },
+    },
+  }
+  const expectedCss = `
+    .my-spinner {
+      position: relative;
+      color: transparent !important;
+      pointer-events: none;
+    }
+
+    .my-spinner::after {
+      content: '';
+      position: absolute !important;
+      top: calc(50% - (1em / 2));
+      left: calc(50% - (1em / 2));
+      display: block;
+      width: 1em;
+      height: 1em;
+      border: 2px solid #dae1e7;
+      border-radius: 9999px;
+      border-right-color: transparent;
+      border-top-color: transparent;
+      animation: spinAround 500ms infinite linear;
+    }
+
+    .my-spinner-md {
+      position: relative;
+      color: transparent !important;
+      pointer-events: none;
+    }
+
+    .my-spinner-md::after {
+      content: '';
+      position: absolute !important;
+      top: calc(50% - (2em / 2));
+      left: calc(50% - (2em / 2));
+      display: block;
+      width: 2em;
+      height: 2em;
+      border: 2px solid currentColor;
+      border-radius: 9999px;
+      border-right-color: transparent;
+      border-top-color: transparent;
+      animation: spinAround 500ms infinite linear;
+    }
+
+    @keyframes spinAround {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+
+    @media (min-width: 640px) {
+      .sm\\:my-spinner {
+        position: relative;
+        color: transparent !important;
+        pointer-events: none;
+      }
+
+      .sm\\:my-spinner::after {
+        content: '';
+        position: absolute !important;
+        top: calc(50% - (1em / 2));
+        left: calc(50% - (1em / 2));
+        display: block;
+        width: 1em;
+        height: 1em;
+        border: 2px solid #dae1e7;
+        border-radius: 9999px;
+        border-right-color: transparent;
+        border-top-color: transparent;
+        animation: spinAround 500ms infinite linear;
+      }
+
+      .sm\\:my-spinner-md {
+        position: relative;
+        color: transparent !important;
+        pointer-events: none;
+      }
+
+      .sm\\:my-spinner-md::after {
+        content: '';
+        position: absolute !important;
+        top: calc(50% - (2em / 2));
+        left: calc(50% - (2em / 2));
+        display: block;
+        width: 2em;
+        height: 2em;
+        border: 2px solid currentColor;
+        border-radius: 9999px;
+        border-right-color: transparent;
+        border-top-color: transparent;
+        animation: spinAround 500ms infinite linear;
+      }
+    }
+  `
+
+  return generatePluginCss(
+    testConfig,
+    { className: 'my-spinner', themeKey: 'customSpinner' }
+  ).then(css => expect(css).toMatchCss(expectedCss))
+})


### PR DESCRIPTION
Hey!

There is a [documented](https://tailwindcss.com/docs/plugins/) way to declale tailwind plugins. Using this method it is possible to `require` plugin without additional call like it was requested [here](https://github.com/aniftyco/tailwindcss-spinner/pull/10#pullrequestreview-404243266).

This pull request implements plugin the "right" way + test for direct `require` now passes.

P.S. I guess it wasn't the best idea to make pull request from same repo/branch, cause it includes old commits (from previous merge). File diff is good though.